### PR TITLE
Fixe h4 formatting in src/dom/README.md

### DIFF
--- a/src/dom/README.md
+++ b/src/dom/README.md
@@ -368,7 +368,7 @@ listSame1.equals(["Mercury", "Venus", "Earth", "Mars"]); // returns true
 listSame1.equals(["Mercury", "Venus", "Earth"]); // returns false because the lists differ with one element "Mars"
 ```
 
-####Struct Example
+#### Struct Example
 ```javascript
 let structSame1: Value = load(
   "foo::bar::{" +


### PR DESCRIPTION
Markdown parsers expect headers to have a space between the hash symbols and the text. The missing space prevented `####Struct Example` from being rendered as an h4.

### Example

#### With Space

####Without Space